### PR TITLE
状態管理ライブラリをrecoilに変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "next": "12.2.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "recharts": "^2.1.12"
+        "recharts": "^2.1.12",
+        "recoil": "^0.7.4"
       },
       "devDependencies": {
         "@types/node": "18.0.3",
@@ -2063,6 +2064,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3288,6 +3294,25 @@
       "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
       "dependencies": {
         "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/reduce-css-calc": {
@@ -5343,6 +5368,11 @@
         "slash": "^3.0.0"
       }
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6184,6 +6214,14 @@
       "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
       "requires": {
         "decimal.js-light": "^2.4.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz",
+      "integrity": "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "reduce-css-calc": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "next": "12.2.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "recharts": "^2.1.12"
+    "recharts": "^2.1.12",
+    "recoil": "^0.7.4"
   },
   "devDependencies": {
     "@types/node": "18.0.3",

--- a/src/components/game-detail/index.tsx
+++ b/src/components/game-detail/index.tsx
@@ -1,23 +1,25 @@
 import { useContext } from "react";
+import { useRecoilValue } from "recoil";
 import ScoreLineChart from "../ScoreLineChart";
 import GameDetailTable from "../gameDetailTable";
-import { GameInfoStoreContext } from "@/lib/gameInfoProvider";
-import { PlayerInfoContext } from "@/lib/playerInfoProvider";
+import { gameInfoByUuid } from "@/lib/gameInfo/selectors";
+import { playerInfoAtom } from "@/lib/playerInfo/atoms";
+import { GameDetailByUuidState } from "@/lib/playerInfo/selectors";
 
 type Props = {
   UUID: string;
-}
+};
 export function GameDetail({ UUID }: Props) {
-  const { gstoreState, gstoreDispatch } = useContext(GameInfoStoreContext)
-  const { pinfoState, pinfoDispatch } = useContext(PlayerInfoContext)
-  const gameInfo = gstoreState.info.find(({metadata}) => metadata.uuid === UUID)!
-  const playerResults = gameInfo.metadata.accountIds.map(accountId => (
-    pinfoState[accountId].stat.gameResultStore.get(UUID)!
-  ))
+  const gameInfo = useRecoilValue(gameInfoByUuid(UUID));
+  console.log("gameInfo:", gameInfo)
+  const playerResults = useRecoilValue(
+    GameDetailByUuidState({ UUID, accountIds: gameInfo.metadata.accountIds }),
+  );
+  console.log("playerResults: ", playerResults)
   return (
     <div className="container">
-      <ScoreLineChart metadata={gameInfo.metadata} playerResults={playerResults}/>
-      <GameDetailTable metadata={gameInfo.metadata} playerResults={playerResults}/>
+      <ScoreLineChart metadata={gameInfo.metadata} playerResults={playerResults} />
+      <GameDetailTable metadata={gameInfo.metadata} playerResults={playerResults} />
     </div>
-  )
+  );
 }

--- a/src/components/game-result/index.tsx
+++ b/src/components/game-result/index.tsx
@@ -1,16 +1,24 @@
 import { TrashIcon } from "@heroicons/react/solid";
 import { useContext, useState } from "react";
+import { useRecoilValue } from "recoil";
 import FileInputField from "../fileinput-field";
 import { GameDetail } from "../game-detail";
-import { GameInfoStoreContext } from "@/lib/gameInfoProvider";
+import { useAddPaifu, useToggleShowGameDetail } from "@/lib/gameInfo/operations";
+import { gameInfoState } from "@/lib/gameInfo/selectors";
+import { playerInfoAtom } from "@/lib/playerInfo/atoms";
+import { useUpdatePlayerStats } from "@/lib/playerInfo/operations";
 import { PlayerInfoContext } from "@/lib/playerInfoProvider";
 import { ConvertToMjaiFormat } from "@/lib/stats";
 
 export function GameResult() {
-  const { pinfoDispatch, pinfoState } = useContext(PlayerInfoContext);
-  const { gstoreDispatch, gstoreState } = useContext(GameInfoStoreContext);
-  console.log("pstorestate:", gstoreState);
-  const handleFileChange = async (
+  //const { pinfoDispatch, pinfoState } = useContext(PlayerInfoContext);
+  const playerInfo = useRecoilValue(playerInfoAtom);
+  const updatePlayerStats = useUpdatePlayerStats()
+  const addPaifu = useAddPaifu()
+  const toggleShowGameDetail = useToggleShowGameDetail()
+  const gameInfo = useRecoilValue(gameInfoState);
+  console.log("pstorestate:", playerInfo);
+  const useHandleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     const target = event.currentTarget as HTMLInputElement;
@@ -18,12 +26,11 @@ export function GameResult() {
     for (const file of Object.values(files)) {
       const text = await file.text();
       const [events, metadata] = ConvertToMjaiFormat(JSON.parse(text));
-      gstoreDispatch({
-        type: "ADD_PAIFU",
-        payload: metadata,
-      });
+      addPaifu(metadata);
       for (const playerId of [0, 1, 2, 3]) {
         console.log("add player:", metadata.playerNames[playerId]);
+        updatePlayerStats(playerId, events, metadata);
+        /*
         pinfoDispatch({
           type: "UPDATE_PLAYER_STATS",
           payload: {
@@ -31,11 +38,11 @@ export function GameResult() {
             events,
             metadata,
           },
-        });
+        });*/
       }
     }
   };
-  console.log(pinfoState);
+  //console.log(pinfoState);
   return (
     <div className="w-full">
       <table className="w-full">
@@ -45,7 +52,7 @@ export function GameResult() {
             <th>プレイヤー</th>
           </tr>
         </thead>
-        {gstoreState.info.map(({ metadata, showDetail }) => (
+        {gameInfo.map(({ metadata, showDetail }) => (
           <tbody key={metadata.uuid}>
             <tr
               className="border-b text-left"
@@ -62,10 +69,7 @@ export function GameResult() {
               <td>
                 <button
                   onClick={() => {
-                    gstoreDispatch({
-                      type: "TOGGLE_SHOW_DETAIL",
-                      payload: { uuid: metadata.uuid },
-                    });
+                    toggleShowGameDetail(metadata.uuid)
                   }}
                 >
                   詳細ページ
@@ -88,7 +92,7 @@ export function GameResult() {
           </tbody>
         ))}
       </table>
-      <FileInputField onChange={handleFileChange}></FileInputField>
+      <FileInputField onChange={useHandleFileChange}></FileInputField>
     </div>
   );
 }

--- a/src/components/playerStatsTable.tsx
+++ b/src/components/playerStatsTable.tsx
@@ -11,11 +11,11 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { useContext, useState } from "react";
+import { useRecoilValue } from "recoil";
 import { classNames } from "../lib/class-names";
 import { Stat } from "../lib/stats";
-import { GameMetadata, GameResultByPlayer } from "../lib/stats/types/stat";
 import { toPercentFormat } from "../lib/stats/utils";
-import { PlayerInfoContext } from "@/lib/playerInfoProvider";
+import { playerInfoAtom } from "@/lib/playerInfo/atoms";
 
 const columns: ColumnDef<Stat>[] = [
   {
@@ -119,10 +119,10 @@ const columns: ColumnDef<Stat>[] = [
 ];
 
 function StatsTable() {
-  const { pinfoState } = useContext(PlayerInfoContext);
+  const  playerInfo = useRecoilValue(playerInfoAtom)
   const [sorting, setSorting] = useState<SortingState>([]);
   const [data, setData] = useState(() =>
-    Object.entries(pinfoState).map(([_, playerInfo]) => playerInfo.stat)
+    Object.entries(playerInfo).map(([_, s]) => s.stat)
   );
   const table = useReactTable({
     data,

--- a/src/lib/gameInfo/atoms.ts
+++ b/src/lib/gameInfo/atoms.ts
@@ -1,0 +1,7 @@
+import { atom } from "recoil"
+import { GameInfoAtom } from "./types"
+
+export const gameInfoAtom = atom<GameInfoAtom>({
+    key: "gameInfo",
+    default: []
+})

--- a/src/lib/gameInfo/operations.ts
+++ b/src/lib/gameInfo/operations.ts
@@ -1,0 +1,23 @@
+import { useRecoilCallback } from "recoil";
+import { GameMetadata } from "../stats/types/stat";
+import { gameInfoAtom } from "./atoms";
+
+export const useAddPaifu = () =>
+  useRecoilCallback(({ set }) => (metadata: GameMetadata) => {
+    set(gameInfoAtom, (prev) =>
+      prev.findIndex((gameInfo) => gameInfo.metadata.uuid === metadata.uuid) === -1
+        ? [...prev, { metadata, showDetail: false }]
+        : prev,
+    );
+  });
+
+export const useToggleShowGameDetail = () =>
+  useRecoilCallback(({ set }) => (uuid: string) => {
+    set(gameInfoAtom, (prev) =>
+      prev.map((gameInfo) =>
+        gameInfo.metadata.uuid === uuid
+          ? { ...gameInfo, showDetail: !gameInfo.showDetail }
+          : gameInfo,
+      ),
+    );
+  });

--- a/src/lib/gameInfo/selectors.ts
+++ b/src/lib/gameInfo/selectors.ts
@@ -1,0 +1,16 @@
+import { selector, selectorFamily } from "recoil";
+
+import { gameInfoAtom } from "./atoms"
+import { GameInfo } from "./types"
+
+export const gameInfoState = selector({
+    key: "gameInfoAtom",
+    get: ({ get }) => (get(gameInfoAtom))
+})
+export const gameInfoByUuid = selectorFamily<GameInfo, string>({
+    key: "gameInfoByUuid",
+    get: (UUID: string) => ({ get }) => {
+        const gameInfo = get(gameInfoAtom).find((gameInfo) => gameInfo.metadata.uuid === UUID)
+        return gameInfo!
+    }
+})

--- a/src/lib/gameInfo/types.ts
+++ b/src/lib/gameInfo/types.ts
@@ -1,0 +1,14 @@
+import { GameMetadata } from "../stats/types/stat";
+import { UiState } from "../utils";
+
+export type GameInfo = {
+    metadata: GameMetadata,
+    showDetail: boolean,
+}
+
+export type GameInfoAtom = GameInfo[]
+
+export type GameInfoUiState = UiState<
+    | { status: "Loading"; gameInfo: GameInfo[] }
+    | { status: "Loaded"; gameInfo: GameInfo[] }
+>;

--- a/src/lib/playerInfo/atoms.ts
+++ b/src/lib/playerInfo/atoms.ts
@@ -1,0 +1,7 @@
+import { atom } from "recoil"
+import { PlayerInfoAtom } from "./types"
+
+export const playerInfoAtom = atom<PlayerInfoAtom>({
+    key: "playerInfo",
+    default: {}
+})

--- a/src/lib/playerInfo/operations.ts
+++ b/src/lib/playerInfo/operations.ts
@@ -1,0 +1,31 @@
+import { useRecoilCallback } from "recoil";
+import { Event } from "../stats";
+import Stat, { GameMetadata } from "../stats/types/stat";
+import { playerInfoAtom } from "./atoms";
+import { PlayerInfo, PlayerInfoAtom } from "./types";
+
+export const useUpdatePlayerStats = () =>
+  useRecoilCallback(
+    ({ set, snapshot }) =>
+      (playerId: number, events: Event[], metadata: GameMetadata) => {
+        let preState = snapshot.getLoadable<PlayerInfoAtom>(playerInfoAtom).contents;
+        let accountId = metadata.accountIds[playerId];
+        console.log("accountId", accountId);
+        let playerInfo: PlayerInfo = { stat: new Stat(), uuids: [] };
+
+        if (preState[accountId]) {
+          playerInfo.stat = Stat.add(playerInfo.stat, preState[accountId].stat);
+        }
+        
+        if (!playerInfo.uuids.includes(metadata.uuid)) {
+          playerInfo.stat = Stat.updateFromEvents(playerInfo.stat, events, playerId);
+          console.log("update playerInfo", playerInfo, preState[accountId]);
+          playerInfo.uuids.push(metadata.uuid);
+          console.log(`${playerInfo.stat.playerName}:`,playerInfo)
+          set(playerInfoAtom, () => ({
+            ...preState,
+            [accountId]: playerInfo,
+          }));
+        }
+      },
+  );

--- a/src/lib/playerInfo/selectors.ts
+++ b/src/lib/playerInfo/selectors.ts
@@ -1,0 +1,27 @@
+import { selector, selectorFamily } from "recoil";
+import { GameResultByPlayer } from "../stats/types/stat";
+import { playerInfoAtom } from "./atoms";
+import { PlayerInfoAtom } from "./types";
+
+export const playerInfoState = selector({
+  key: "playerInfoAtom",
+  get: ({ get }) => get(playerInfoAtom),
+});
+
+type GameDetailByUuidParams = {
+  UUID: string;
+  accountIds: string[];
+};
+export const GameDetailByUuidState = selectorFamily<GameResultByPlayer[][], GameDetailByUuidParams>(
+  {
+    key: "GameDetailByUuid",
+    get:
+      ({ UUID, accountIds }) =>
+      ({ get }) => {
+        const playerInfo = get(playerInfoAtom);
+        const players = accountIds.map((accountId) => playerInfo[accountId]);
+        const gameDetail = players.map((player) => player.stat.gameResultStore.get(UUID)!);
+        return gameDetail;
+      },
+  },
+);

--- a/src/lib/playerInfo/types.ts
+++ b/src/lib/playerInfo/types.ts
@@ -1,0 +1,10 @@
+import { Stat } from "../stats"
+
+export type PlayerInfo = {
+    stat: Stat;
+    uuids: string[];
+}
+
+export type PlayerInfoAtom = {
+    [x: string]: PlayerInfo
+}

--- a/src/lib/playerInfoProvider.tsx
+++ b/src/lib/playerInfoProvider.tsx
@@ -41,7 +41,7 @@ function reducer(state: PlayerInfoType, action: PlayerInfoActionType): PlayerInf
       }
       if (!playerInfo.uuids.includes(metadata.uuid)) {
         console.log("new data:", metadata.uuid);
-        playerInfo.stat.updateFromEvents(events, playerId);
+        playerInfo.stat = Stat.updateFromEvents(playerInfo.stat, events, playerId);
         playerInfo.uuids.push(metadata.uuid);
         return {
           ...state,

--- a/src/lib/stats/types/stat.ts
+++ b/src/lib/stats/types/stat.ts
@@ -176,7 +176,63 @@ class Stat {
     this.gameResultStore = new Map();
   }
 
-  updateFromEvents(events: Event[], player_id: number) {
+  static add(lsh: Stat, rsh: Stat): Stat {
+    const result = new Stat();
+    result.playerId = lsh.playerId;
+    result.playerName = lsh.playerName;
+    result.playerNameUpdatedAt = lsh.playerNameUpdatedAt;
+    result.game = lsh.game + rsh.game;
+    result.round = lsh.round + rsh.round;
+    result.oya = lsh.oya + rsh.oya;
+    result.agari = lsh.agari + rsh.agari;
+    result.agariJun = lsh.agariJun + rsh.agariJun;
+    result.agariAsOya = lsh.agariAsOya + rsh.agariAsOya;
+    result.agariPointOya = lsh.agariPointOya + rsh.agariPointOya;
+    result.agariPointKo = lsh.agariPointKo + rsh.agariPointKo;
+    result.riichi = lsh.riichi + rsh.riichi;
+    result.riichiJun = lsh.riichiJun + rsh.riichiJun;
+    result.riichiAgari = lsh.riichiAgari + rsh.riichiAgari;
+    result.riichiAgariJun = lsh.riichiAgariJun + rsh.riichiAgariJun;
+    result.riichiAgariPoint = lsh.riichiAgariPoint + rsh.riichiAgariPoint;
+    result.riichiPoint = lsh.riichiPoint + rsh.riichiPoint;
+    result.riichiHoujuu = lsh.riichiHoujuu + rsh.riichiHoujuu;
+    result.riichiAsOya = lsh.riichiAsOya + rsh.riichiAsOya;
+    result.okkakeRiichi = lsh.okkakeRiichi + rsh.okkakeRiichi;
+    result.okkakerareRiichi = lsh.okkakerareRiichi + rsh.okkakerareRiichi;
+    result.fuuro = lsh.fuuro + rsh.fuuro;
+    result.fuuroNum = lsh.fuuroNum + rsh.fuuroNum;
+    result.fuuroAgari = lsh.fuuroAgari + rsh.fuuroAgari;
+    result.fuuroAgariJun = lsh.fuuroAgariJun + rsh.fuuroAgariJun;
+    result.fuuroAgariPoint = lsh.fuuroAgariPoint + rsh.fuuroAgariPoint;
+    result.fuuroPoint = lsh.fuuroPoint + rsh.fuuroPoint;
+    result.fuuroHoujuu = lsh.fuuroHoujuu + rsh.fuuroHoujuu;
+    result.damaAgari = lsh.damaAgari + rsh.damaAgari;
+    result.damaAgariJun = lsh.damaAgariJun + rsh.damaAgariJun;
+    result.damaAgariPoint = lsh.damaAgariPoint + rsh.damaAgariPoint;
+    result.yakuman = lsh.yakuman + rsh.yakuman;
+    result.nagashiMangan = lsh.nagashiMangan + rsh.nagashiMangan;
+    result.houjuu = lsh.houjuu + rsh.houjuu;
+    result.houjuuJun = lsh.houjuuJun + rsh.houjuuJun;
+    result.houjuuToOya = lsh.houjuuToOya + rsh.houjuuToOya;
+    result.houjuuPointToOya = lsh.houjuuPointToOya + rsh.houjuuPointToOya;
+    result.houjuuPointToKo = lsh.houjuuPointToKo + rsh.houjuuPointToKo;
+    result.ryukyoku = lsh.ryukyoku + rsh.ryukyoku;
+    result.ryukyokuPoint = lsh.ryukyokuPoint + rsh.ryukyokuPoint;
+    result.riichiRyukyoku = lsh.riichiRyukyoku + rsh.riichiRyukyoku;
+    result.teampoint = lsh.teampoint + rsh.teampoint;
+    result.point = lsh.point + rsh.point;
+    result.rank1 = lsh.rank1 + rsh.rank1;
+    result.rank2 = lsh.rank2 + rsh.rank2;
+    result.rank3 = lsh.rank3 + rsh.rank3;
+    result.rank4 = lsh.rank4 + rsh.rank4;
+    result.tobi = lsh.tobi + rsh.tobi;
+    result.gameResultStore = new Map([...lsh.gameResultStore, ...rsh.gameResultStore]);
+    return result;
+  }
+
+  static updateFromEvents(preStat: Stat, events: Event[], player_id: number): Stat {
+    let stat = new Stat();
+    stat = Stat.add(stat, preStat);
     let curScores = [0, 0, 0, 0];
     let finalScore = 0;
     let riichiDeclared = false;
@@ -193,19 +249,32 @@ class Stat {
     let state = "";
     let result = "";
     let uuid = "";
-    this.game++;
+    stat.game++;
     for (const event of events) {
       const type = event.type;
       if (type === "startGame") {
         uuid = event.uuid;
       } else if (type === "startKyoku") {
-        const { oya, scores, bakaze, kyotaku, kyoku, honba, playerNames, accountIds, unixTimestamp } = event;
-        this.round++;
-        if (this.playerName !== playerNames[player_id] && this.playerNameUpdatedAt < unixTimestamp) {
-          this.playerName = playerNames[player_id];
-          this.playerNameUpdatedAt = unixTimestamp;
+        const {
+          oya,
+          scores,
+          bakaze,
+          kyotaku,
+          kyoku,
+          honba,
+          playerNames,
+          accountIds,
+          unixTimestamp,
+        } = event;
+        stat.round++;
+        if (
+          stat.playerName !== playerNames[player_id] &&
+          stat.playerNameUpdatedAt < unixTimestamp
+        ) {
+          stat.playerName = playerNames[player_id];
+          stat.playerNameUpdatedAt = unixTimestamp;
         }
-        this.playerId = accountIds[player_id];
+        stat.playerId = accountIds[player_id];
 
         curScores = [...scores];
         curKyotaku = kyotaku;
@@ -217,7 +286,7 @@ class Stat {
         state = "";
         result = "";
         if (curOya === player_id) {
-          this.oya++;
+          stat.oya++;
         }
         kyokuState = {
           kyoku: kyokuInfoToString(bakaze, kyoku, honba),
@@ -240,16 +309,16 @@ class Stat {
         const { actor } = event;
         if (actor === player_id) {
           riichiDeclared = true;
-          this.riichi++;
-          this.riichiJun += jun;
+          stat.riichi++;
+          stat.riichiJun += jun;
           if (curOya === player_id) {
-            this.riichiAsOya++;
+            stat.riichiAsOya++;
           }
           if (othersRiichiDeclared) {
-            this.okkakeRiichi++;
+            stat.okkakeRiichi++;
           }
         } else if (riichiDeclared) {
-          this.okkakerareRiichi++;
+          stat.okkakerareRiichi++;
         } else {
           othersRiichiDeclared = true;
         }
@@ -269,57 +338,57 @@ class Stat {
         if (actor === player_id) {
           result = tsumo ? "ツモ" : "ロン";
           let point = deltas[player_id] - Number(riichiAccepted) * 1000;
-          this.agari++;
-          this.agariJun += jun;
+          stat.agari++;
+          stat.agariJun += jun;
 
           if (curOya === player_id) {
-            this.agariAsOya++;
-            this.agariPointOya += point;
+            stat.agariAsOya++;
+            stat.agariPointOya += point;
           } else {
-            this.agariPointKo += point;
+            stat.agariPointKo += point;
           }
 
           if (riichiAccepted) {
-            this.riichiAgari++;
-            this.riichiAgariJun += jun;
-            this.riichiAgariPoint += point;
-            this.riichiPoint += point;
+            stat.riichiAgari++;
+            stat.riichiAgariJun += jun;
+            stat.riichiAgariPoint += point;
+            stat.riichiPoint += point;
           } else if (fuuroNum > 0) {
-            this.fuuroAgari++;
-            this.fuuroAgariJun += jun;
-            this.fuuroAgariPoint += point;
-            this.fuuroPoint += point;
+            stat.fuuroAgari++;
+            stat.fuuroAgariJun += jun;
+            stat.fuuroAgariPoint += point;
+            stat.fuuroPoint += point;
           } else {
-            this.damaAgari++;
-            this.damaAgariJun += jun;
-            this.damaAgariPoint += point;
+            stat.damaAgari++;
+            stat.damaAgariJun += jun;
+            stat.damaAgariPoint += point;
           }
 
           if (
             (curOya === player_id && point >= 48000) ||
             (curOya !== player_id && point >= 32000)
           ) {
-            this.yakuman++;
+            stat.yakuman++;
           }
         } else if (target === player_id) {
           result = "放銃";
           let point = deltas[player_id];
-          this.houjuu++;
-          this.houjuuJun += jun;
+          stat.houjuu++;
+          stat.houjuuJun += jun;
 
           if (curOya === actor) {
-            this.houjuuToOya++;
-            this.houjuuPointToOya += point;
+            stat.houjuuToOya++;
+            stat.houjuuPointToOya += point;
           } else {
-            this.houjuuPointToKo += point;
+            stat.houjuuPointToKo += point;
           }
 
           if (riichiDeclared) {
-            this.riichiHoujuu++;
-            this.riichiPoint += point;
+            stat.riichiHoujuu++;
+            stat.riichiPoint += point;
           } else if (fuuroNum > 0) {
-            this.fuuroHoujuu++;
-            this.fuuroPoint += point;
+            stat.fuuroHoujuu++;
+            stat.fuuroPoint += point;
           }
         }
       } else if (type === "ryukyoku") {
@@ -332,22 +401,22 @@ class Stat {
         }
 
         let point = deltas[player_id];
-        this.ryukyoku++;
-        this.ryukyokuPoint += point;
+        stat.ryukyoku++;
+        stat.ryukyokuPoint += point;
         if (riichiAccepted) {
-          this.riichiRyukyoku++;
-          this.riichiPoint += point - 1000;
+          stat.riichiRyukyoku++;
+          stat.riichiPoint += point - 1000;
         } else if (fuuroNum > 0) {
-          this.fuuroPoint += point;
+          stat.fuuroPoint += point;
         }
 
         if (point >= 8000) {
-          this.nagashiMangan++;
+          stat.nagashiMangan++;
         }
       } else if (type === "endKyoku") {
         if (fuuroNum > 0) {
-          this.fuuro++;
-          this.fuuroNum += fuuroNum;
+          stat.fuuro++;
+          stat.fuuroNum += fuuroNum;
         }
         kyokuState.ryukyoku = isRyukyoku ? "流局" : "";
         if (fuuroNum > 0) {
@@ -366,24 +435,25 @@ class Stat {
       } else if (type === "endGame") {
         const { finalScores, ranks, teampoints } = event;
         finalScore = finalScores[player_id];
-        this.point += finalScore - 25000;
-        this.teampoint += teampoints[player_id];
+        stat.point += finalScore - 25000;
+        stat.teampoint += teampoints[player_id];
         if (finalScore < 0) {
-          this.tobi++;
+          stat.tobi++;
         }
         const rank = ranks[player_id];
         if (rank === 0) {
-          this.rank1++;
+          stat.rank1++;
         } else if (rank === 1) {
-          this.rank2++;
+          stat.rank2++;
         } else if (rank === 2) {
-          this.rank3++;
+          stat.rank3++;
         } else if (rank === 3) {
-          this.rank4++;
+          stat.rank4++;
         }
-        this.gameResultStore.set(uuid, gameResult);
+        stat.gameResultStore.set(uuid, gameResult);
       }
     }
+    return stat
   }
 
   #totalPt(points: number[]) {

--- a/src/lib/teamInfoProvider.tsx
+++ b/src/lib/teamInfoProvider.tsx
@@ -1,0 +1,9 @@
+
+export const TeamInfoContext = createContext<TeamInfoContextType>({} as {
+    tinfoState: TeamInfoType;
+    tinfoDispatch: Dispatch<TeamInfoActionType>;
+})
+type TeamInfo = {
+    teamNames: string[]
+    player
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,3 +3,7 @@ type ArrayOfLength<N extends number, T> = ArrayOfLengthRec<N, T, []>;
 type ArrayOfLengthRec<Num, Elm, T extends unknown[]> = T["length"] extends Num ? T : ArrayOfLengthRec<Num, Elm, [Elm, ...T]>
 
 export type { ArrayOfLength };
+
+// 
+// 参考: https://zenn.dev/warabi/articles/2521222d57a71f
+export type UiState<T extends { status: string } & Record<string, unknown>> = T;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,18 +1,18 @@
 import "../../styles/globals.css";
 import type { AppProps } from "next/app";
+import { RecoilRoot } from "recoil";
 import Layout from "@/components/layout";
-import { PaifuStoreProvider } from "@/lib/gameInfoProvider";
 import { PlayerInfoProvider } from "@/lib/playerInfoProvider";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <PlayerInfoProvider>
-      <PaifuStoreProvider>
-        <Layout>
-          <Component {...pageProps} />
-        </Layout>
-      </PaifuStoreProvider>
-    </PlayerInfoProvider>
+    <RecoilRoot>
+      <PlayerInfoProvider>
+          <Layout>
+            <Component {...pageProps} />
+          </Layout>
+      </PlayerInfoProvider>
+    </RecoilRoot>
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,6 +1114,11 @@
     "merge2" "^1.4.1"
     "slash" "^3.0.0"
 
+"hamt_plus@1.0.2":
+  "integrity" "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+  "resolved" "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz"
+  "version" "1.0.2"
+
 "has-bigints@^1.0.1", "has-bigints@^1.0.2":
   "integrity" "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
   "resolved" "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz"
@@ -1785,7 +1790,7 @@
     "prop-types" "^15.6.2"
     "react-lifecycles-compat" "^3.0.4"
 
-"react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@^18.2.0", "react@>= 16", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=15.0.0", "react@>=16", "react@18.2.0":
+"react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^17.0.2 || ^18.0.0-0", "react@^18.2.0", "react@>= 16", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>=15.0.0", "react@>=16", "react@>=16.13.1", "react@18.2.0":
   "integrity" "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="
   "resolved" "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   "version" "18.2.0"
@@ -1829,6 +1834,13 @@
     "react-smooth" "^2.0.1"
     "recharts-scale" "^0.4.4"
     "reduce-css-calc" "^2.1.8"
+
+"recoil@^0.7.4":
+  "integrity" "sha512-sCXvQGMfSprkNU4ZRkJV4B0qFQSURJMgsICqY1952WRlg66NMwYqi6n67vhnhn0qw4zHU1gHXJuMvRDaiRNFZw=="
+  "resolved" "https://registry.npmjs.org/recoil/-/recoil-0.7.4.tgz"
+  "version" "0.7.4"
+  dependencies:
+    "hamt_plus" "1.0.2"
 
 "reduce-css-calc@^2.1.8":
   "integrity" "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg=="


### PR DESCRIPTION
各プレイヤーの成績や試合の詳細だけでなく、どのチームに所属しているかなどを状態として持つことや状態同士の依存関係(チーごとの成績を出すなど)が増えることを考えると、状態管理用のライブラリを使った方がいいんじゃないかと思いrecoilを使ってみた